### PR TITLE
Add hacks for making rule names pretty

### DIFF
--- a/dist/flx/lib/main.dart
+++ b/dist/flx/lib/main.dart
@@ -230,7 +230,8 @@ class CallMenuItem extends StatelessComponent {
     if (interpretation.hasInterpretation) {
       return new Block([
         new Column([
-          new Text(interpretation.ruleName, style: const TextStyle(fontWeight: FontWeight.bold)),
+          new Text(displayRuleName(interpretation.ruleName),
+            style: const TextStyle(fontWeight: FontWeight.bold)),
           new KnowledgeText(knowledge: interpretation.knowledge),
         ], justifyContent: FlexJustifyContent.center, alignItems: FlexAlignItems.start)
       ], scrollDirection: ScrollDirection.horizontal);

--- a/dist/flx/lib/model.dart
+++ b/dist/flx/lib/model.dart
@@ -201,6 +201,16 @@ class CallHistory {
   }
 }
 
+String displayRuleName(String ruleName) {
+  String displayName = ruleName.replaceAllMapped(
+      new RegExp(r'([1-9A-Z])'), (Match m) => ' ${m[1]}');
+  // A couple exceptions to the spacing rules:
+  displayName = displayName.replaceAll('R H O', 'RHO');
+  displayName = displayName.replaceAll('L H O', 'LHO');
+  displayName = displayName.replaceAll(new RegExp(r'\sN$'), 'NT');
+  return displayName;
+}
+
 class CallInterpretation {
   const CallInterpretation({
     this.ruleName,


### PR DESCRIPTION
Converts CamelCase to Space Separated following
the code from gae/scripts/view.coffee.

@abarth